### PR TITLE
minimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM debian:buster
+FROM debian:buster-slim
 
 RUN apt-get update && \
-    apt-get install -y sudo python3 python3-magic python3-pil poppler-utils graphicsmagick ghostscript tesseract-ocr tesseract-ocr-all libreoffice
-
-RUN useradd -ms /bin/bash user
+    apt-get install -y --no-install-recommends sudo python3 python3-magic python3-pil poppler-utils graphicsmagick ghostscript tesseract-ocr tesseract-ocr-all libreoffice && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -ms /bin/bash user
 
 COPY scripts/* /usr/local/bin/


### PR DESCRIPTION
By regrouping all steps in a single one, we remove an intermediate
tarball, and therefore build size.

We also use `apt-get clean` to remove the fetched packages and clear
out the result of the `apt-get update`, which shaves off a few more
bytes.

Finally, we use the "buster-slim" image and avoid installing
"recommends".

 * Before: 2.29GB
 * After: 1.41GB