### PR TITLE
do not assume base image is up to date, upgrade anyways

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:buster-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends sudo python3 python3-magic python3-pil poppler-utils graphicsmagick ghostscript tesseract-ocr tesseract-ocr-all libreoffice && \
+    apt-get upgrade -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -ms /bin/bash user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM debian:buster
+FROM debian:buster-slim
 
 RUN apt-get update && \
-    apt-get install -y sudo python3 python3-magic python3-pil poppler-utils graphicsmagick ghostscript tesseract-ocr tesseract-ocr-all libreoffice
-
-RUN useradd -ms /bin/bash user
+    apt-get install -y --no-install-recommends sudo python3 python3-magic python3-pil poppler-utils graphicsmagick ghostscript tesseract-ocr tesseract-ocr-all libreoffice && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    useradd -ms /bin/bash user
 
 COPY scripts/* /usr/local/bin/


### PR DESCRIPTION
This makes sure we have the latest and greatest security updates, regardless of the Debian base image.
    
The base image might be lagging behind for different reasons:
    
 * the Docker hub image is out of date
 * the local image is already present and pull policies don't pull the latest upstream
    
This will make the image slightly bigger, but should hopefully be worth it.

This is based on top of #5 