### PR TITLE
WIP: Docker container hardening and batch processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,3 @@ COPY scripts/* /usr/local/bin/
 VOLUME /dangerzone /tmp /safezone
 
 USER user
-
-# to run this:
-#
-# PIXEL_DIR=pixels
-# SAFE_DIR=safe
-# DOCKER_HARDENING="--network none --security-opt=no-new-privileges:true"
-# mkdir $PIXEL_DIR $SAFE_DIR
-# chmod g+w $PIXEL_DIR $SAFE_DIR
-# sudo chown 10000 $PIXEL_DIR $SAFE_DIR
-# docker run $DOCKER_HARDENING -v $PIXEL_DIR:/dangerzone -v $DOCUMENT_FILENAME:/tmp/input_file flmcode/dangerzone document-to-pixels-unpriv
-# docker run $DOCKER_HARDENING -v $PIXEL_DIR:/dangerzone -v $SAFE_DIR:/safezone -e OCR=$OCR -e OCR_LANGUAGE=$OCR_LANG flmcode/dangerzone pixels-to-pdf-unpriv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && \
+RUN DEBIAN_FRONTEND=noninteractive && \
+    export DEBIAN_FRONTEND && \
+    apt-get update && \
     apt-get install --yes --no-install-recommends \
         ghostscript \
         graphicsmagick \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN DEBIAN_FRONTEND=noninteractive && \
         python3 \
         python3-magic \
         python3-pil \
-        sudo \
         tesseract-ocr \
         tesseract-ocr-all \
         && \
@@ -29,3 +28,16 @@ COPY scripts/* /usr/local/bin/
 #
 # /safezone is where the wrapper eventually moves the sanitized files.
 VOLUME /dangerzone /tmp /safezone
+
+USER user
+
+# to run this:
+#
+# PIXEL_DIR=pixels
+# SAFE_DIR=safe
+# DOCKER_HARDENING="--network none --security-opt=no-new-privileges:true"
+# mkdir $PIXEL_DIR $SAFE_DIR
+# chmod g+w $PIXEL_DIR $SAFE_DIR
+# sudo chown 10000 $PIXEL_DIR $SAFE_DIR
+# docker run $DOCKER_HARDENING -v $PIXEL_DIR:/dangerzone -v $DOCUMENT_FILENAME:/tmp/input_file flmcode/dangerzone document-to-pixels-unpriv
+# docker run $DOCKER_HARDENING -v $PIXEL_DIR:/dangerzone -v $SAFE_DIR:/safezone -e OCR=$OCR -e OCR_LANGUAGE=$OCR_LANG flmcode/dangerzone pixels-to-pdf-unpriv

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,11 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     useradd --no-log-init --create-home --shell /bin/bash user
 
 COPY scripts/* /usr/local/bin/
+
+# /tmp is where the first convert expects the input file to be, and
+# where it will write the pixel files
+#
+# /dangerzone is where the second script expects files to be put by the first one
+#
+# /safezone is where the wrapper eventually moves the sanitized files.
+VOLUME /dangerzone /tmp /safezone

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,21 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends sudo python3 python3-magic python3-pil poppler-utils graphicsmagick ghostscript tesseract-ocr tesseract-ocr-all libreoffice && \
-    apt-get upgrade -y && \
+    apt-get install --yes --no-install-recommends \
+        ghostscript \
+        graphicsmagick \
+        libreoffice \
+        poppler-utils \
+        python3 \
+        python3-magic \
+        python3-pil \
+        sudo \
+        tesseract-ocr \
+        tesseract-ocr-all \
+        && \
+    apt-get upgrade --yes && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd -ms /bin/bash user
+    useradd --no-log-init --create-home --shell /bin/bash user
 
 COPY scripts/* /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     apt-get upgrade --yes && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    useradd --no-log-init --create-home --shell /bin/bash user
+    useradd --no-log-init --create-home --shell /bin/bash -K UID_MIN=10000 -K GID_MIN=10000 user
 
 COPY scripts/* /usr/local/bin/
 

--- a/batch-convert.py
+++ b/batch-convert.py
@@ -195,6 +195,7 @@ class Sanitizer():
         logging.info("generated %d pages", pages)
 
         with tempfile.TemporaryDirectory() as pixel_dir:
+            os.chmod(pixel_dir, 0o755)
             for page in range(1, pages + 1):
                 for type in ("rgb", "width", "height"):
                     self.runner.cp(f"{container_id}:/tmp/page-{page}.{type}", pixel_dir)

--- a/batch-convert.py
+++ b/batch-convert.py
@@ -150,12 +150,8 @@ def sanitize_file(path, safe_dir, image, cmd_output):
                     )
                 except subprocess.CalledProcessError as e:
                     logging.warning("failed to copy file %s: %s", type, e)
-        if cmd_output:
-            stdout = None
-        else:
-            stdout = subprocess.DEVNULL
         subprocess.run(
-            ("docker", "rm", container_id), check=True, stdout=stdout
+            ("docker", "rm", container_id), check=True, stdout=subprocess.DEVNULL
         )
         container_id, _ = runner.run(
             # -e OCR="$OCR" -e OCR_LANGUAGE="$OCR_LANG"
@@ -173,7 +169,7 @@ def sanitize_file(path, safe_dir, image, cmd_output):
             )
         )
         subprocess.run(
-            ("docker", "rm", container_id), check=True, stdout=stdout
+            ("docker", "rm", container_id), check=True, stdout=subprocess.DEVNULL
         )
 
 

--- a/batch-convert.py
+++ b/batch-convert.py
@@ -142,26 +142,28 @@ class DockerRunner(object):
         return container_id, output
 
     def cp(self, source, target):
+        cmd = (
+            "docker",
+            "cp",
+            source,
+            target,
+        )
         if self.dryrun:
-            logging.info("would run: docker cp %s %s", source, target)
+            logging.debug("would run: %s", cmd)
             return
+        logging.debug("running: %s", cmd)
         try:
-            subprocess.check_call((
-                "docker",
-                "cp",
-                source,
-                target,
-            ))
+            subprocess.check_call(cmd)
         except subprocess.CalledProcessError as e:
-            logging.warning("failed to copy file %s: %s", type, e)
+            logging.warning("failed to copy file: %s", e)
 
     def rm(self, container_id):
+        cmd = ("docker", "rm", container_id)
         if self.dryrun:
-            logging.info("would run: docker rm %s", container_id)
+            logging.debug("would run: %s", cmd)
             return
-        subprocess.run(
-            ("docker", "rm", container_id), check=True, stdout=subprocess.DEVNULL,
-        )
+        logging.debug("running: %s", cmd)
+        subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL)
 
 
 class Sanitizer():

--- a/batch-convert.py
+++ b/batch-convert.py
@@ -154,10 +154,14 @@ def main():
             container_id = fp.read().strip()
 
     logging.info("stage 2 completed in container %s", container_id)
-    for path in ("safe-output.pdf", "safe-output-compressed.pdf"):
-        subprocess.check_call(
-            ("docker", "cp", f"{container_id}:/tmp/{path}", args.safe_dir)
+    subprocess.check_call(
+        (
+            "docker",
+            "cp",
+            f"{container_id}:/tmp/safe-output-compressed.pdf",
+            os.path.join(args.safe_dir, os.path.basename(args.document)),
         )
+    )
     subprocess.check_call(("docker", "rm", container_id))
     shutil.rmtree(args.pixel_dir)
 

--- a/batch-convert.py
+++ b/batch-convert.py
@@ -25,6 +25,11 @@ class BatchArgParser(argparse.ArgumentParser):
             help="where to store temporary files, default: %(default)s",
         )
         self.add_argument(
+            "--image",
+            default="flmcode/dangerzone",
+            help="Docker image to use, default %(default)s",
+        )
+        self.add_argument(
             "-v",
             "--verbose",
             action=LoggingAction,
@@ -102,7 +107,7 @@ def main():
             os.path.abspath(args.document) + ":/tmp/input_file",
         ]
         cmd += DOCKER_HARDENING
-        cmd += ("flmcode/dangerzone", "document-to-pixels-unpriv")
+        cmd += (args.image, "document-to-pixels-unpriv")
         output = subprocess.check_output(cmd)
         print(output.decode("utf-8"))
         with open(f"{tmpdir}/cidfile") as fp:
@@ -142,7 +147,7 @@ def main():
             # -e OCR="$OCR" -e OCR_LANGUAGE="$OCR_LANG"
         ]
         cmd += DOCKER_HARDENING
-        cmd += ("flmcode/dangerzone", "pixels-to-pdf-unpriv")
+        cmd += (args.image, "pixels-to-pdf-unpriv")
         subprocess.check_call(cmd)
         with open(f"{tmpdir}/cidfile") as fp:
             container_id = fp.read().strip()

--- a/batch-convert.py
+++ b/batch-convert.py
@@ -1,0 +1,154 @@
+#!/usr/bin/python3
+
+import argparse
+import logging
+import os
+import os.path
+import re
+import subprocess
+import sys
+import tempfile
+
+
+class BatchArgParser(argparse.ArgumentParser):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_argument("document", help="document to sanitize")
+        self.add_argument(
+            "--safe-dir",
+            default="safe/",
+            help="where to store sanitized files, default: %(default)s",
+        )
+        self.add_argument(
+            "--pixel-dir",
+            default="pixel/",
+            help="where to store temporary files, default: %(default)s",
+        )
+        self.add_argument(
+            "-v",
+            "--verbose",
+            action=LoggingAction,
+            const="INFO",
+            help="enable verbose messages",
+        )
+        self.add_argument(
+            "-d",
+            "--debug",
+            action=LoggingAction,
+            const="DEBUG",
+            help="enable debugging messages",
+        )
+
+
+class LoggingAction(argparse.Action):
+    """change log level on the fly
+
+    The logging system should be initialized befure this, using
+    `basicConfig`.
+
+    Example usage:
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action=LoggingAction,
+        const="INFO",
+        help="enable verbose messages",
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action=LoggingAction,
+        const="DEBUG",
+        help="enable debugging messages",
+    )
+    """
+
+    def __init__(self, *args, **kwargs):
+        """setup the action parameters
+
+        This enforces a selection of logging levels. It also checks if
+        const is provided, in which case we assume it's an argument
+        like `--verbose` or `--debug` without an argument.
+        """
+        kwargs["choices"] = logging._nameToLevel.keys()
+        if "const" in kwargs:
+            kwargs["nargs"] = 0
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, parser, ns, values, option):
+        """if const was specified it means argument-less parameters"""
+        if self.const:
+            logging.getLogger("").setLevel(self.const)
+        else:
+            logging.getLogger("").setLevel(values)
+
+
+def main():
+    logging.basicConfig(format='%(message)s')
+    args = BatchArgParser().parse_args()
+    os.makedirs(args.safe_dir, exist_ok=True)
+    os.makedirs(args.pixel_dir, exist_ok=True)
+    pixel_dir = os.path.abspath(args.pixel_dir)
+
+    DOCKER_HARDENING = ("--network", "none", "--security-opt=no-new-privileges:true")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cmd = [
+            "docker",
+            "run",
+            "-it",  # to get the output
+            f"--cidfile={tmpdir}/cidfile",  # to get the container ID
+            "--volume",
+            os.path.abspath(args.document) + ":/tmp/input_file",
+        ]
+        cmd += DOCKER_HARDENING
+        cmd += ("flmcode/dangerzone", "document-to-pixels-unpriv")
+        output = subprocess.check_output(cmd)
+        print(output.decode('utf-8'))
+        with open(f"{tmpdir}/cidfile") as fp:
+            container_id = fp.read().strip()
+
+    logging.info("stage 1 completed in container %s", container_id)
+    m = re.search(rb"Document has (\d+) pages", output)
+    if not m:
+        logging.error("failed to find page numbers")
+        sys.exit(1)
+    pages = int(m.group(1))
+    logging.info("generated %d pages", pages)
+
+    for page in range(1, pages+1):
+        for type in ('rgb', 'width', 'height'):
+            try:
+                subprocess.check_call(
+                    ("docker", "cp", f"{container_id}:/tmp/page-{page}.{type}", args.pixel_dir)
+                )
+            except subprocess.CalledProcessError as e:
+                logging.warning("failed to copy file %s: %s", type, e)
+    subprocess.check_call(('docker', 'rm', container_id))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cmd = [
+            "docker",
+            "run",
+            "-it",  # to get the output
+            f"--cidfile={tmpdir}/cidfile",  # to get the container ID
+            "--volume",
+            f'{pixel_dir}:/dangerzone',
+            # -e OCR="$OCR" -e OCR_LANGUAGE="$OCR_LANG"
+        ]
+        cmd += DOCKER_HARDENING
+        cmd += ("flmcode/dangerzone", "pixels-to-pdf-unpriv")
+        subprocess.check_call(cmd)
+        with open(f"{tmpdir}/cidfile") as fp:
+            container_id = fp.read().strip()
+
+    logging.info("stage 2 completed in container %s", container_id)
+    for path in ('safe-output.pdf', 'safe-output-compressed.pdf'):
+        subprocess.check_call(
+            ("docker", "cp", f"{container_id}:/tmp/{path}", args.safe_dir)
+        )
+    subprocess.check_call(('docker', 'rm', container_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/batch-convert.py
+++ b/batch-convert.py
@@ -85,7 +85,7 @@ class LoggingAction(argparse.Action):
 
 
 def main():
-    logging.basicConfig(format='%(message)s')
+    logging.basicConfig(format="%(message)s")
     args = BatchArgParser().parse_args()
     os.makedirs(args.safe_dir, exist_ok=True)
     os.makedirs(args.pixel_dir, exist_ok=True)
@@ -104,7 +104,7 @@ def main():
         cmd += DOCKER_HARDENING
         cmd += ("flmcode/dangerzone", "document-to-pixels-unpriv")
         output = subprocess.check_output(cmd)
-        print(output.decode('utf-8'))
+        print(output.decode("utf-8"))
         with open(f"{tmpdir}/cidfile") as fp:
             container_id = fp.read().strip()
 
@@ -116,15 +116,20 @@ def main():
     pages = int(m.group(1))
     logging.info("generated %d pages", pages)
 
-    for page in range(1, pages+1):
-        for type in ('rgb', 'width', 'height'):
+    for page in range(1, pages + 1):
+        for type in ("rgb", "width", "height"):
             try:
                 subprocess.check_call(
-                    ("docker", "cp", f"{container_id}:/tmp/page-{page}.{type}", args.pixel_dir)
+                    (
+                        "docker",
+                        "cp",
+                        f"{container_id}:/tmp/page-{page}.{type}",
+                        args.pixel_dir,
+                    )
                 )
             except subprocess.CalledProcessError as e:
                 logging.warning("failed to copy file %s: %s", type, e)
-    subprocess.check_call(('docker', 'rm', container_id))
+    subprocess.check_call(("docker", "rm", container_id))
 
     with tempfile.TemporaryDirectory() as tmpdir:
         cmd = [
@@ -133,7 +138,7 @@ def main():
             "-it",  # to get the output
             f"--cidfile={tmpdir}/cidfile",  # to get the container ID
             "--volume",
-            f'{pixel_dir}:/dangerzone',
+            f"{pixel_dir}:/dangerzone",
             # -e OCR="$OCR" -e OCR_LANGUAGE="$OCR_LANG"
         ]
         cmd += DOCKER_HARDENING
@@ -143,11 +148,11 @@ def main():
             container_id = fp.read().strip()
 
     logging.info("stage 2 completed in container %s", container_id)
-    for path in ('safe-output.pdf', 'safe-output-compressed.pdf'):
+    for path in ("safe-output.pdf", "safe-output-compressed.pdf"):
         subprocess.check_call(
             ("docker", "cp", f"{container_id}:/tmp/{path}", args.safe_dir)
         )
-    subprocess.check_call(('docker', 'rm', container_id))
+    subprocess.check_call(("docker", "rm", container_id))
 
 
 if __name__ == "__main__":

--- a/batch-convert.py
+++ b/batch-convert.py
@@ -5,6 +5,7 @@ import logging
 import os
 import os.path
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -158,6 +159,7 @@ def main():
             ("docker", "cp", f"{container_id}:/tmp/{path}", args.safe_dir)
         )
     subprocess.check_call(("docker", "rm", container_id))
+    shutil.rmtree(args.pixel_dir)
 
 
 if __name__ == "__main__":

--- a/scripts/document-to-pixels-unpriv
+++ b/scripts/document-to-pixels-unpriv
@@ -15,6 +15,11 @@ def print_flush(s):
 
 
 def main():
+    # should have no trailing slash, but that should not matter
+    # because one is added anyways
+    dangerzone_dir = "/tmp"
+    input_file = f"{dangerzone_dir}/input_file"
+
     conversions = {
         # .pdf
         "application/pdf": {"type": None},
@@ -86,7 +91,7 @@ def main():
 
     # Detect MIME type
     mime = magic.Magic(mime=True)
-    mime_type = mime.from_file("/tmp/input_file")
+    mime_type = mime.from_file(input_file)
 
     # Validate MIME type
     if mime_type not in conversions:
@@ -96,7 +101,7 @@ def main():
     # Convert input document to PDF
     conversion = conversions[mime_type]
     if conversion["type"] is None:
-        pdf_filename = "/tmp/input_file"
+        pdf_filename = input_file
     elif conversion["type"] == "libreoffice":
         print_flush(f"Converting to PDF using LibreOffice")
         args = [
@@ -105,8 +110,8 @@ def main():
             "--convert-to",
             f"pdf:{conversion['libreoffice_output_filter']}",
             "--outdir",
-            "/tmp",
-            "/tmp/input_file",
+            dangerzone_dir,
+            input_file,
         ]
         try:
             p = subprocess.run(args, timeout=60)
@@ -119,14 +124,15 @@ def main():
         if p.returncode != 0:
             print_flush(f"Conversion to PDF failed: {p.stdout}")
             sys.exit(1)
-        pdf_filename = "/tmp/input_file.pdf"
+        pdf_filename = f"{input_file}.pdf"
     elif conversion["type"] == "convert":
+        pdf_filename = f"{input_file}.pdf"
         print_flush(f"Converting to PDF using GraphicsMagick")
         args = [
             "gm",
             "convert",
-            "/tmp/input_file",
-            "/tmp/input_file.pdf",
+            input_file,
+            pdf_filename,
         ]
         try:
             p = subprocess.run(args, timeout=60)
@@ -138,7 +144,6 @@ def main():
         if p.returncode != 0:
             print_flush(f"Conversion to PDF failed: {p.stdout}")
             sys.exit(1)
-        pdf_filename = "/tmp/input_file.pdf"
     else:
         print_flush("Invalid conversion type")
         sys.exit(1)
@@ -146,7 +151,7 @@ def main():
     # Separate PDF into pages
     print_flush("")
     print_flush(f"Separating document into pages")
-    args = ["pdfseparate", pdf_filename, "/tmp/page-%d.pdf"]
+    args = ["pdfseparate", pdf_filename, f"{dangerzone_dir}/page-%d.pdf"]
     try:
         p = subprocess.run(args, timeout=60)
     except subprocess.TimeoutExpired:
@@ -158,18 +163,18 @@ def main():
         print_flush(f"Separating document into pages failed: {p.stdout}")
         sys.exit(1)
 
-    page_filenames = glob.glob("/tmp/page-*.pdf")
+    page_filenames = glob.glob(f"{dangerzone_dir}/page-*.pdf")
     print_flush(f"Document has {len(page_filenames)} pages")
     print_flush("")
 
     # Convert to RGB pixel data
     for page in range(1, len(page_filenames) + 1):
-        pdf_filename = f"/tmp/page-{page}.pdf"
-        png_filename = f"/tmp/page-{page}.png"
-        rgb_filename = f"/tmp/page-{page}.rgb"
-        width_filename = f"/tmp/page-{page}.width"
-        height_filename = f"/tmp/page-{page}.height"
-        filename_base = f"/tmp/page-{page}"
+        pdf_filename = f"{dangerzone_dir}/page-{page}.pdf"
+        png_filename = f"{dangerzone_dir}/page-{page}.png"
+        rgb_filename = f"{dangerzone_dir}/page-{page}.rgb"
+        width_filename = f"{dangerzone_dir}/page-{page}.width"
+        height_filename = f"{dangerzone_dir}/page-{page}.height"
+        filename_base = f"{dangerzone_dir}/page-{page}"
 
         print_flush(f"Converting page {page} to pixels")
 

--- a/scripts/pixels-to-pdf-unpriv
+++ b/scripts/pixels-to-pdf-unpriv
@@ -11,18 +11,22 @@ def print_flush(s=""):
 
 
 def main():
-    num_pages = len(glob.glob("/dangerzone/page-*.rgb"))
+    # should have no trailing slash, but that should not matter
+    # because one is added anyways
+    dangerzone_dir = "/dangerzone"
+    safezone_dir = "/tmp"
+    num_pages = len(glob.glob(f"{dangerzone_dir}/page-*.rgb"))
     print_flush(f"Document has {num_pages} pages")
 
     # Convert RGB files to PDF files
     for page in range(1, num_pages + 1):
-        filename_base = f"/dangerzone/page-{page}"
+        filename_base = f"{dangerzone_dir}/page-{page}"
         rgb_filename = f"{filename_base}.rgb"
         width_filename = f"{filename_base}.width"
         height_filename = f"{filename_base}.height"
-        png_filename = f"/tmp/page-{page}.png"
-        ocr_filename = f"/tmp/page-{page}"
-        pdf_filename = f"/tmp/page-{page}.pdf"
+        png_filename = f"{safezone_dir}/page-{page}.png"
+        ocr_filename = f"{safezone_dir}/page-{page}"
+        pdf_filename = f"{safezone_dir}/page-{page}.pdf"
 
         with open(width_filename) as f:
             width = f.read().strip()
@@ -104,8 +108,8 @@ def main():
     print_flush(f"Merging {num_pages} pages into a single PDF")
     args = ["pdfunite"]
     for page in range(1, num_pages + 1):
-        args.append(f"/tmp/page-{page}.pdf")
-    args.append(f"/tmp/safe-output.pdf")
+        args.append(f"{safezone_dir}/page-{page}.pdf")
+    args.append(f"{safezone_dir}/safe-output.pdf")
     try:
         p = subprocess.run(args, timeout=60)
     except subprocess.TimeoutExpired:
@@ -122,7 +126,7 @@ def main():
     compress_timeout = num_pages * 3
     try:
         p = subprocess.run(
-            ["ps2pdf", "/tmp/safe-output.pdf", "/tmp/safe-output-compressed.pdf"],
+            ["ps2pdf", f"{safezone_dir}/safe-output.pdf", f"{safezone_dir}/safe-output-compressed.pdf"],
             timeout=compress_timeout,
         )
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
So this is my first, incomplete, stab at [hardening the container](https://github.com/firstlookmedia/dangerzone/issues/52).

It should definitely not be merged as is, because it will break the dangerzone frontend itself. It's just a basis for discussion. In this (and 6daceea in particular), I establish a stronger privilege separation by running *all* commands inside the container using the lower-privileged user. I also make sure that user doesn't have a commonly used UID (e.g. 1000) so that we profit from that privilege separation as well.

Before this change, the container would run as root, and then the wrapper scripts would use `sudo` to drop privileges. Considering there has been, in the past, vulnerabilities in `sudo`, this seems less than ideal. It also makes audits much more complicated because this Dockerfile has a red flag: no "USER" directive.

Obviously, this breaks dangerzone itself, because the directories shared by the frontend will not have the right permission and the container won't be able to write files there. I dropped instructions in the Dockerfile on how to workaround those issues, but those are far from ideal: they basically require root on the host to create a directory owned by the funky user.

An alternative would be to assume a single-user system (ie. that the calling user is UID=1000), but then that provides lesser privilege separation, because the container actually runs as a privileged user, which likely has sudo access, juicy stuff in their ~/.ssh/ or ~/.gnupg/ directories, or at the very least have a writable ~/.bashrc to drop backdoors into.

There are also [discussions in Docker itself on how to handle stuff like this](https://github.com/moby/moby/issues/2259): typically, people use wrapper scripts (like originally done here) or a shared group. Another alternative is to use `docker cp` to copy files out of the container when done. This is probably the way forward, in this case. Don't use a shared volume at all: just use the ephemeral filesystem created inside the container, keep the container around after execution completes, `docker cp` the files out, and *then* destroy the container.

This is built on top of #6 and #5. It jumbles a bunch of other changes in because I had to clear up the Dockerfile a little more to see things through. I'm happy to file separate PRs for those, but since the commits all conflict with each other, I felt it was better to wait and see what would happen with #5 and #6 before going any further (which is another reason why this is marked as WIP).