### PR TITLE
Base container off of ubuntu:20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends sudo python3 python3-magic python3-pil poppler-utils graphicsmagick ghostscript tesseract-ocr tesseract-ocr-all libreoffice && \


### PR DESCRIPTION
I used Snyk to scan the dangerzone container for vulnerabilities (using `docker scan dangerzone`) and it says it found many in the current `debian:buster-slim`-based container.

I also tested `debian:bullseye-slim` and `ubuntu:20.04`, and it looks like switching to Ubuntu includes software with the least number of vulnerabilities, and zero high severity ones. Also, the `ubuntu:20.04`-based container is 1.35gb, which is slightly smaller than the version based on `debian:buster-slim`.

## debian:buster-slim

`Tested 514 dependencies for known vulnerabilities, found 240 vulnerabilities.`

- 62 high severity
- 29 medium severity
- 149 low severity

High severity vulns include things like:

```
✗ High severity vulnerability found in libreoffice/uno-libs3
  Description: Directory Traversal
  Info: https://snyk.io/vuln/SNYK-DEBIAN10-LIBREOFFICE-341806
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libreoffice/uno-libs3@6.1.5-3+deb10u7
  From: meta-common-packages@meta > libreoffice/ure@6.1.5-3+deb10u7
  Image layer: 'RUN /bin/sh -c apt-get update &&     apt-get install -y --no-install-recommends sudo python3 python3-magic python3-pil poppler-utils graphicsmagick ghostscript tesseract-ocr tesseract-ocr-all libreoffice &&     apt-get upgrade -y &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd -ms /bin/bash user '
  Fixed in: 1:6.1.3-1
```

## debian:bullseye-slim

`Tested 481 dependencies for known vulnerabilities, found 95 vulnerabilities.`

- 7 high severity
- 0 medium severity
- 88 low severity

## ubuntu:20.04 (LTS)

`Tested 466 dependencies for known vulnerabilities, found 54 vulnerabilities.`

- 0 high severity
- 11 medium severity
- 43 low severity
