### PR TITLE
Port from ubuntu:20.04 to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,95 @@
-FROM ubuntu:20.04
+FROM alpine:latest
 
-RUN DEBIAN_FRONTEND=noninteractive && \
-    export DEBIAN_FRONTEND && \
-    apt-get update && \
-    apt-get install --yes --no-install-recommends \
-    default-jre \
+# Install dependencies
+RUN apk -U upgrade && \
+    apk add \
     ghostscript \
     graphicsmagick \
     libreoffice \
-    libreoffice-java-common \
-    pdftk \
+    openjdk8 \
     poppler-utils \
-    python3 \
-    python3-magic \
-    python3-pil \
+    py3-magic \
+    py3-pillow \
     sudo \
     tesseract-ocr \
-    tesseract-ocr-all \
-    && \
-    apt-get upgrade --yes && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    useradd --no-log-init --create-home --shell /bin/bash user
+    tesseract-ocr-data-afr \
+    tesseract-ocr-data-ara \
+    tesseract-ocr-data-aze \
+    tesseract-ocr-data-bel \
+    tesseract-ocr-data-ben \
+    tesseract-ocr-data-bul \
+    tesseract-ocr-data-cat \
+    tesseract-ocr-data-ces \
+    tesseract-ocr-data-chi_sim \
+    tesseract-ocr-data-chi_tra \
+    tesseract-ocr-data-chr \
+    tesseract-ocr-data-dan \
+    tesseract-ocr-data-deu \
+    tesseract-ocr-data-ell \
+    tesseract-ocr-data-enm \
+    tesseract-ocr-data-epo \
+    tesseract-ocr-data-equ \
+    tesseract-ocr-data-est \
+    tesseract-ocr-data-eus \
+    tesseract-ocr-data-fin \
+    tesseract-ocr-data-fra \
+    tesseract-ocr-data-frk \
+    tesseract-ocr-data-frm \
+    tesseract-ocr-data-glg \
+    tesseract-ocr-data-grc \
+    tesseract-ocr-data-heb \
+    tesseract-ocr-data-hin \
+    tesseract-ocr-data-hrv \
+    tesseract-ocr-data-hun \
+    tesseract-ocr-data-ind \
+    tesseract-ocr-data-isl \
+    tesseract-ocr-data-ita \
+    tesseract-ocr-data-ita_old \
+    tesseract-ocr-data-jpn \
+    tesseract-ocr-data-kan \
+    tesseract-ocr-data-kat \
+    tesseract-ocr-data-kor \
+    tesseract-ocr-data-lav \
+    tesseract-ocr-data-lit \
+    tesseract-ocr-data-mal \
+    tesseract-ocr-data-mkd \
+    tesseract-ocr-data-mlt \
+    tesseract-ocr-data-msa \
+    tesseract-ocr-data-nld \
+    tesseract-ocr-data-nor \
+    tesseract-ocr-data-pol \
+    tesseract-ocr-data-por \
+    tesseract-ocr-data-ron \
+    tesseract-ocr-data-rus \
+    tesseract-ocr-data-slk \
+    tesseract-ocr-data-slv \
+    tesseract-ocr-data-spa \
+    tesseract-ocr-data-spa_old \
+    tesseract-ocr-data-sqi \
+    tesseract-ocr-data-srp \
+    tesseract-ocr-data-swa \
+    tesseract-ocr-data-swe \
+    tesseract-ocr-data-tam \
+    tesseract-ocr-data-tel \
+    tesseract-ocr-data-tgl \
+    tesseract-ocr-data-tha \
+    tesseract-ocr-data-tur \
+    tesseract-ocr-data-ukr \
+    tesseract-ocr-data-vie
+
+# Install pdftk
+RUN \
+    wget https://gitlab.com/pdftk-java/pdftk/-/jobs/924565145/artifacts/raw/build/libs/pdftk-all.jar && \
+    mv pdftk-all.jar /usr/local/bin && \
+    chmod +x /usr/local/bin/pdftk-all.jar && \
+    echo '#!/bin/sh' > /usr/local/bin/pdftk && \
+    echo '/usr/bin/java -jar "/usr/local/bin/pdftk-all.jar" "$@"' >> /usr/local/bin/pdftk && \
+    chmod +x /usr/local/bin/pdftk
 
 COPY scripts/* /usr/local/bin/
+
+# Add the unprivileged user
+RUN adduser -h /home/user -s /bin/sh -D user
 
 # /tmp/input_file is where the first convert expects the input file to be, and
 # /tmp where it will write the pixel files

--- a/scripts/document-to-pixels
+++ b/scripts/document-to-pixels
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Remove this warning by setting the host in /etc/hosts:
 # sudo: unable to resolve host 8160b021d811: Temporary failure in name resolution

--- a/scripts/pixels-to-pdf
+++ b/scripts/pixels-to-pdf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Remove this warning by setting the host in /etc/hosts:
 # sudo: unable to resolve host 8160b021d811: Temporary failure in name resolution


### PR DESCRIPTION
This only saves a little disk space (the ubuntu-based container is 1.65GB and the alpine-based one is 1.55GB), but it has half the packages installed and zero known vulnerabilities (instead of 60 low/medium severity vulns) when scanning it with Snyk:

```
$ docker scan dangerzone-alpine

Testing dangerzone-alpine...

Package manager:   apk
Project name:      docker-image|dangerzone-alpine
Docker image:      dangerzone-alpine
Platform:          linux/amd64

✓ Tested 287 dependencies for known vulnerabilities, no vulnerable paths found.

For more free scans that keep your images secure, sign up to Snyk at https://dockr.ly/3ePqVcp
```

Compared the ubuntu-based one:

```
$ docker scan flmcode/dangerzone

Testing flmcode/dangerzone...

✗ Low severity vulnerability found in yajl/libyajl2
  Description: Use of Externally-Controlled Format String
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-YAJL-580043
  Introduced through: libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > redland/librdf0@1.0.17-1.1ubuntu1 > raptor2/libraptor2-0@2.0.15-0ubuntu1.20.04.1 > yajl/libyajl2@2.1.0-3
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in xorg/x11-common
  Description: Link Following
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-XORG-576651
  Introduced through: java-common/default-jre@2:1.11-72, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: java-common/default-jre@2:1.11-72 > openjdk-lts/openjdk-11-jre@11.0.11+9-0ubuntu2~20.04 > libxtst/libxtst6@2:1.2.3-1 > xorg/x11-common@1:7.7+19ubuntu14
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > libice/libice6@2:1.0.10-0ubuntu1 > xorg/x11-common@1:7.7+19ubuntu14
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in tiff/libtiff5
  Description: NULL Pointer Dereference
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-TIFF-577862
  Introduced through: pillow/python3-pil@7.0.0-4ubuntu0.4, ghostscript@9.50~dfsg-5ubuntu4.2, graphicsmagick@1.4+really1.3.35-1, tesseract/tesseract-ocr@4.1.1-2build2, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: pillow/python3-pil@7.0.0-4ubuntu0.4 > tiff/libtiff5@4.1.0+git191117-2ubuntu0.20.04.1
  From: ghostscript@9.50~dfsg-5ubuntu4.2 > ghostscript/libgs9@9.50~dfsg-5ubuntu4.2 > tiff/libtiff5@4.1.0+git191117-2ubuntu0.20.04.1
  From: graphicsmagick@1.4+really1.3.35-1 > graphicsmagick/libgraphicsmagick-q16-3@1.4+really1.3.35-1 > tiff/libtiff5@4.1.0+git191117-2ubuntu0.20.04.1
  and 2 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in sqlite3/libsqlite3-0
  Description: CVE-2020-9991
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-SQLITE3-1070680
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > sqlite3/libsqlite3-0@3.31.1-4ubuntu0.2

✗ Low severity vulnerability found in sqlite3/libsqlite3-0
  Description: Information Exposure
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-SQLITE3-1070691
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > sqlite3/libsqlite3-0@3.31.1-4ubuntu0.2

✗ Low severity vulnerability found in shadow/passwd
  Description: Time-of-check Time-of-use (TOCTOU)
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-SHADOW-577863
  Introduced through: shadow/passwd@1:4.8.1-1ubuntu5.20.04, adduser@3.118ubuntu2, shadow/login@1:4.8.1-1ubuntu5.20.04, java-common/default-jre@2:1.11-72
  From: shadow/passwd@1:4.8.1-1ubuntu5.20.04
  From: adduser@3.118ubuntu2 > shadow/passwd@1:4.8.1-1ubuntu5.20.04
  From: shadow/login@1:4.8.1-1ubuntu5.20.04
  and 1 more...

✗ Low severity vulnerability found in python3.8/libpython3.8-stdlib
  Description: HTTP Request Smuggling
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-PYTHON38-1075582
  Introduced through: libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/python3-uno@1:6.4.7-0ubuntu0.20.04.1 > python3.8/libpython3.8@3.8.5-1~20.04.3 > python3.8/libpython3.8-stdlib@3.8.5-1~20.04.3
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/python3-uno@1:6.4.7-0ubuntu0.20.04.1 > python3-defaults/python3@3.8.2-0ubuntu2 > python3-defaults/libpython3-stdlib@3.8.2-0ubuntu2 > python3.8/libpython3.8-stdlib@3.8.5-1~20.04.3
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/python3-uno@1:6.4.7-0ubuntu0.20.04.1 > python3-defaults/python3@3.8.2-0ubuntu2 > python3.8@3.8.5-1~20.04.3 > python3.8/libpython3.8-stdlib@3.8.5-1~20.04.3
  and 7 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in poppler/libpoppler97
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-POPPLER-578310
  Introduced through: poppler/poppler-utils@0.86.1-0ubuntu1, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: poppler/poppler-utils@0.86.1-0ubuntu1 > poppler/libpoppler97@0.86.1-0ubuntu1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > poppler/libpoppler97@0.86.1-0ubuntu1
  From: poppler/poppler-utils@0.86.1-0ubuntu1
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in poppler/libpoppler97
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-POPPLER-583172
  Introduced through: poppler/poppler-utils@0.86.1-0ubuntu1, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: poppler/poppler-utils@0.86.1-0ubuntu1 > poppler/libpoppler97@0.86.1-0ubuntu1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > poppler/libpoppler97@0.86.1-0ubuntu1
  From: poppler/poppler-utils@0.86.1-0ubuntu1
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in pcre3/libpcre3
  Description: Uncontrolled Recursion
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-PCRE3-580031
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > pcre3/libpcre3@2:8.39-12build1

✗ Low severity vulnerability found in pcre3/libpcre3
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-PCRE3-581164
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > pcre3/libpcre3@2:8.39-12build1

✗ Low severity vulnerability found in pcre3/libpcre3
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-PCRE3-583594
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > pcre3/libpcre3@2:8.39-12build1

✗ Low severity vulnerability found in openjpeg2/libopenjp2-7
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-OPENJPEG2-1246557
  Introduced through: ghostscript@9.50~dfsg-5ubuntu4.2, tesseract/tesseract-ocr@4.1.1-2build2, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: ghostscript@9.50~dfsg-5ubuntu4.2 > ghostscript/libgs9@9.50~dfsg-5ubuntu4.2 > openjpeg2/libopenjp2-7@2.3.1-1ubuntu4.20.04.1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1 > openjpeg2/libopenjp2-7@2.3.1-1ubuntu4.20.04.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > poppler/libpoppler97@0.86.1-0ubuntu1 > openjpeg2/libopenjp2-7@2.3.1-1ubuntu4.20.04.1
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in openjpeg2/libopenjp2-7
  Description: Allocation of Resources Without Limits or Throttling
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-OPENJPEG2-577727
  Introduced through: ghostscript@9.50~dfsg-5ubuntu4.2, tesseract/tesseract-ocr@4.1.1-2build2, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: ghostscript@9.50~dfsg-5ubuntu4.2 > ghostscript/libgs9@9.50~dfsg-5ubuntu4.2 > openjpeg2/libopenjp2-7@2.3.1-1ubuntu4.20.04.1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1 > openjpeg2/libopenjp2-7@2.3.1-1ubuntu4.20.04.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > poppler/libpoppler97@0.86.1-0ubuntu1 > openjpeg2/libopenjp2-7@2.3.1-1ubuntu4.20.04.1
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in nss/libnss3
  Description: Allocation of Resources Without Limits or Throttling
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-NSS-1019588
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > nss/libnss3@2:3.49.1-1ubuntu1.5

✗ Low severity vulnerability found in libxslt/libxslt1.1
  Description: Use of Insufficiently Random Values
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBXSLT-581844
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libxslt/libxslt1.1@1.1.34-4

✗ Low severity vulnerability found in libxml2
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBXML2-609730
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libxml2@2.9.10+dfsg-5

✗ Low severity vulnerability found in libtasn1-6
  Description: Resource Management Errors
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBTASN16-578037
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libtasn1-6@4.16.0-2

✗ Low severity vulnerability found in libreoffice/fonts-opensymbol
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBREOFFICE-579039
  Introduced through: libreoffice@1:6.4.7-0ubuntu0.20.04.1, libreoffice/libreoffice-java-common@1:6.4.7-0ubuntu0.20.04.1, meta-common-packages@meta
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-math@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/fonts-opensymbol@2:102.11+LibO6.4.7-0ubuntu0.20.04.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/fonts-opensymbol@2:102.11+LibO6.4.7-0ubuntu0.20.04.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-common@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-style-colibre@1:6.4.7-0ubuntu0.20.04.1
  and 43 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in libreoffice/fonts-opensymbol
  Description: Information Exposure
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBREOFFICE-583870
  Introduced through: libreoffice@1:6.4.7-0ubuntu0.20.04.1, libreoffice/libreoffice-java-common@1:6.4.7-0ubuntu0.20.04.1, meta-common-packages@meta
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-math@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/fonts-opensymbol@2:102.11+LibO6.4.7-0ubuntu0.20.04.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/fonts-opensymbol@2:102.11+LibO6.4.7-0ubuntu0.20.04.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-common@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-style-colibre@1:6.4.7-0ubuntu0.20.04.1
  and 43 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in libjpeg-turbo/libjpeg-turbo8
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBJPEGTURBO-1299079
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libjpeg-turbo/libjpeg-turbo8@2.0.3-0ubuntu1.20.04.1

✗ Low severity vulnerability found in libgcrypt20
  Description: CVE-2021-33560
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBGCRYPT20-1297919
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libgcrypt20@1.8.5-5ubuntu1

✗ Low severity vulnerability found in krb5/libgssapi-krb5-2
  Description: Integer Overflow or Wraparound
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-KRB5-579303
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > krb5/libgssapi-krb5-2@1.17-6ubuntu4.1
  From: meta-common-packages@meta > krb5/libk5crypto3@1.17-6ubuntu4.1
  From: meta-common-packages@meta > krb5/libkrb5-3@1.17-6ubuntu4.1
  and 1 more...

✗ Low severity vulnerability found in jbigkit/libjbig0
  Description: Out-of-Bounds
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-JBIGKIT-578320
  Introduced through: graphicsmagick@1.4+really1.3.35-1, ghostscript@9.50~dfsg-5ubuntu4.2
  From: graphicsmagick@1.4+really1.3.35-1 > graphicsmagick/libgraphicsmagick-q16-3@1.4+really1.3.35-1 > jbigkit/libjbig0@2.1-3.1build1
  From: ghostscript@9.50~dfsg-5ubuntu4.2 > ghostscript/libgs9@9.50~dfsg-5ubuntu4.2 > tiff/libtiff5@4.1.0+git191117-2ubuntu0.20.04.1 > jbigkit/libjbig0@2.1-3.1build1
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in jbig2dec/libjbig2dec0
  Description: NULL Pointer Dereference
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-JBIG2DEC-580469
  Introduced through: ghostscript@9.50~dfsg-5ubuntu4.2
  From: ghostscript@9.50~dfsg-5ubuntu4.2 > ghostscript/libgs9@9.50~dfsg-5ubuntu4.2 > jbig2dec/libjbig2dec0@0.18-1ubuntu1
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in graphicsmagick/libgraphicsmagick-q16-3
  Description: Missing Release of Resource after Effective Lifetime
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GRAPHICSMAGICK-578115
  Introduced through: graphicsmagick@1.4+really1.3.35-1
  From: graphicsmagick@1.4+really1.3.35-1 > graphicsmagick/libgraphicsmagick-q16-3@1.4+really1.3.35-1
  From: graphicsmagick@1.4+really1.3.35-1
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in gnutls28/libgnutls30
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GNUTLS28-1085477
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > gnutls28/libgnutls30@3.6.13-2ubuntu1.3

✗ Low severity vulnerability found in gnutls28/libgnutls30
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GNUTLS28-1085499
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > gnutls28/libgnutls30@3.6.13-2ubuntu1.3

✗ Low severity vulnerability found in gnupg2/gpgv
  Description: Improper Certificate Validation
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GNUPG2-578416
  Introduced through: gnupg2/gpgv@2.2.19-3ubuntu2.1, apt@2.0.5, libreoffice@1:6.4.7-0ubuntu0.20.04.1, meta-common-packages@meta
  From: gnupg2/gpgv@2.2.19-3ubuntu2.1
  From: apt@2.0.5 > gnupg2/gpgv@2.2.19-3ubuntu2.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > gpgme1.0/libgpgmepp6@1.13.1-7ubuntu2 > gpgme1.0/libgpgme11@1.13.1-7ubuntu2 > gnupg2/gnupg@2.2.19-3ubuntu2.1 > gnupg2/gpgv@2.2.19-3ubuntu2.1
  and 11 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Reachable Assertion
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-1048386
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-1055780
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-1055790
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Double Free
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-1123084
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-576349
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2

✗ Low severity vulnerability found in glibc/libc-bin
  Description: Integer Underflow
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GLIBC-576428
  Introduced through: glibc/libc-bin@2.31-0ubuntu9.2, meta-common-packages@meta
  From: glibc/libc-bin@2.31-0ubuntu9.2
  From: meta-common-packages@meta > glibc/libc6@2.31-0ubuntu9.2

✗ Low severity vulnerability found in giflib/libgif7
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GIFLIB-1253339
  Introduced through: java-common/default-jre@2:1.11-72, tesseract/tesseract-ocr@4.1.1-2build2
  From: java-common/default-jre@2:1.11-72 > openjdk-lts/openjdk-11-jre@11.0.11+9-0ubuntu2~20.04 > giflib/libgif7@5.1.9-1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1 > giflib/libgif7@5.1.9-1

✗ Low severity vulnerability found in curl/libcurl3-gnutls
  Description: CVE-2021-22898
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-CURL-1296912
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > curl/libcurl3-gnutls@7.68.0-1ubuntu2.5

✗ Low severity vulnerability found in cups/libcups2
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-CUPS-1070128
  Introduced through: ghostscript@9.50~dfsg-5ubuntu4.2, java-common/default-jre@2:1.11-72, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: ghostscript@9.50~dfsg-5ubuntu4.2 > ghostscript/libgs9@9.50~dfsg-5ubuntu4.2 > cups/libcups2@2.3.1-9ubuntu1.1
  From: java-common/default-jre@2:1.11-72 > java-common/default-jre-headless@2:1.11-72 > openjdk-lts/openjdk-11-jre-headless@11.0.11+9-0ubuntu2~20.04 > cups/libcups2@2.3.1-9ubuntu1.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > cups/libcups2@2.3.1-9ubuntu1.1
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in cups/libcups2
  Description: Buffer Overflow
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-CUPS-607952
  Introduced through: ghostscript@9.50~dfsg-5ubuntu4.2, java-common/default-jre@2:1.11-72, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: ghostscript@9.50~dfsg-5ubuntu4.2 > ghostscript/libgs9@9.50~dfsg-5ubuntu4.2 > cups/libcups2@2.3.1-9ubuntu1.1
  From: java-common/default-jre@2:1.11-72 > java-common/default-jre-headless@2:1.11-72 > openjdk-lts/openjdk-11-jre-headless@11.0.11+9-0ubuntu2~20.04 > cups/libcups2@2.3.1-9ubuntu1.1
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-base-core@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-core@1:6.4.7-0ubuntu0.20.04.1 > cups/libcups2@2.3.1-9ubuntu1.1
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in coreutils
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-COREUTILS-583876
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > coreutils@8.30-3ubuntu2

✗ Low severity vulnerability found in cairo/libcairo2
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-CAIRO-576328
  Introduced through: poppler/poppler-utils@0.86.1-0ubuntu1, tesseract/tesseract-ocr@4.1.1-2build2, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: poppler/poppler-utils@0.86.1-0ubuntu1 > cairo/libcairo2@1.16.0-4ubuntu1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > cairo/libcairo2@1.16.0-4ubuntu1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > pango1.0/libpangocairo-1.0-0@1.44.7-2ubuntu4 > cairo/libcairo2@1.16.0-4ubuntu1
  and 1 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in cairo/libcairo2
  Description: NULL Pointer Dereference
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-CAIRO-578123
  Introduced through: poppler/poppler-utils@0.86.1-0ubuntu1, tesseract/tesseract-ocr@4.1.1-2build2, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: poppler/poppler-utils@0.86.1-0ubuntu1 > cairo/libcairo2@1.16.0-4ubuntu1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > cairo/libcairo2@1.16.0-4ubuntu1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > pango1.0/libpangocairo-1.0-0@1.44.7-2ubuntu4 > cairo/libcairo2@1.16.0-4ubuntu1
  and 1 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in cairo/libcairo2
  Description: Reachable Assertion
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-CAIRO-581771
  Introduced through: poppler/poppler-utils@0.86.1-0ubuntu1, tesseract/tesseract-ocr@4.1.1-2build2, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: poppler/poppler-utils@0.86.1-0ubuntu1 > cairo/libcairo2@1.16.0-4ubuntu1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > cairo/libcairo2@1.16.0-4ubuntu1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > pango1.0/libpangocairo-1.0-0@1.44.7-2ubuntu4 > cairo/libcairo2@1.16.0-4ubuntu1
  and 1 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in cairo/libcairo2
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-CAIRO-582581
  Introduced through: poppler/poppler-utils@0.86.1-0ubuntu1, tesseract/tesseract-ocr@4.1.1-2build2, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: poppler/poppler-utils@0.86.1-0ubuntu1 > cairo/libcairo2@1.16.0-4ubuntu1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > cairo/libcairo2@1.16.0-4ubuntu1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > pango1.0/libpangocairo-1.0-0@1.44.7-2ubuntu4 > cairo/libcairo2@1.16.0-4ubuntu1
  and 1 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in cairo/libcairo2
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-CAIRO-584185
  Introduced through: poppler/poppler-utils@0.86.1-0ubuntu1, tesseract/tesseract-ocr@4.1.1-2build2, libreoffice@1:6.4.7-0ubuntu0.20.04.1
  From: poppler/poppler-utils@0.86.1-0ubuntu1 > cairo/libcairo2@1.16.0-4ubuntu1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > cairo/libcairo2@1.16.0-4ubuntu1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > pango1.0/libpangocairo-1.0-0@1.44.7-2ubuntu4 > cairo/libcairo2@1.16.0-4ubuntu1
  and 1 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Low severity vulnerability found in bash
  Description: Improper Check for Dropped Privileges
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-BASH-581100
  Introduced through: bash@5.0-6ubuntu1.1
  From: bash@5.0-6ubuntu1.1

✗ Medium severity vulnerability found in systemd/libudev1
  Description: Authentication Bypass
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-SYSTEMD-1290722
  Introduced through: systemd/libudev1@245.4-4ubuntu3.6, apt@2.0.5, java-common/default-jre@2:1.11-72, meta-common-packages@meta
  From: systemd/libudev1@245.4-4ubuntu3.6
  From: apt@2.0.5 > apt/libapt-pkg6.0@2.0.5 > systemd/libudev1@245.4-4ubuntu3.6
  From: java-common/default-jre@2:1.11-72 > java-common/default-jre-headless@2:1.11-72 > openjdk-lts/openjdk-11-jre-headless@11.0.11+9-0ubuntu2~20.04 > util-linux@2.34-0.1ubuntu9.1 > systemd/libudev1@245.4-4ubuntu3.6
  and 1 more...

✗ Medium severity vulnerability found in sqlite3/libsqlite3-0
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-SQLITE3-581593
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > sqlite3/libsqlite3-0@3.31.1-4ubuntu0.2

✗ Medium severity vulnerability found in nettle/libhogweed5
  Description: CVE-2021-3580
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-NETTLE-1303240
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > nettle/libhogweed5@3.5.1+really3.5.1-2ubuntu0.1
  From: meta-common-packages@meta > nettle/libnettle7@3.5.1+really3.5.1-2ubuntu0.1

✗ Medium severity vulnerability found in libxml2
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBXML2-1278686
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libxml2@2.9.10+dfsg-5

✗ Medium severity vulnerability found in libxml2
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBXML2-1278690
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libxml2@2.9.10+dfsg-5

✗ Medium severity vulnerability found in libxml2
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBXML2-1278694
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libxml2@2.9.10+dfsg-5

✗ Medium severity vulnerability found in libxml2
  Description: NULL Pointer Dereference
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBXML2-1290394
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libxml2@2.9.10+dfsg-5

✗ Medium severity vulnerability found in libxml2
  Description: CVE-2021-3541
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LIBXML2-1295536
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > libxml2@2.9.10+dfsg-5

✗ Medium severity vulnerability found in leptonlib/liblept5
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LEPTONLIB-1086145
  Introduced through: tesseract/tesseract-ocr@4.1.1-2build2
  From: tesseract/tesseract-ocr@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > tesseract/libtesseract4@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1

✗ Medium severity vulnerability found in leptonlib/liblept5
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LEPTONLIB-1086150
  Introduced through: tesseract/tesseract-ocr@4.1.1-2build2
  From: tesseract/tesseract-ocr@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > tesseract/libtesseract4@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1

✗ Medium severity vulnerability found in leptonlib/liblept5
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LEPTONLIB-1086155
  Introduced through: tesseract/tesseract-ocr@4.1.1-2build2
  From: tesseract/tesseract-ocr@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > tesseract/libtesseract4@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1

✗ Medium severity vulnerability found in leptonlib/liblept5
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-LEPTONLIB-1086160
  Introduced through: tesseract/tesseract-ocr@4.1.1-2build2
  From: tesseract/tesseract-ocr@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1
  From: tesseract/tesseract-ocr@4.1.1-2build2 > tesseract/libtesseract4@4.1.1-2build2 > leptonlib/liblept5@1.79.0-1

✗ Medium severity vulnerability found in graphicsmagick/libgraphicsmagick-q16-3
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-GRAPHICSMAGICK-1040488
  Introduced through: graphicsmagick@1.4+really1.3.35-1
  From: graphicsmagick@1.4+really1.3.35-1 > graphicsmagick/libgraphicsmagick-q16-3@1.4+really1.3.35-1
  From: graphicsmagick@1.4+really1.3.35-1
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'

✗ Medium severity vulnerability found in avahi/libavahi-client3
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://snyk.io/vuln/SNYK-UBUNTU2004-AVAHI-1089693
  Introduced through: libreoffice@1:6.4.7-0ubuntu0.20.04.1, java-common/default-jre@2:1.11-72, meta-common-packages@meta
  From: libreoffice@1:6.4.7-0ubuntu0.20.04.1 > libreoffice/libreoffice-draw@1:6.4.7-0ubuntu0.20.04.1 > avahi/libavahi-client3@0.7-4ubuntu7
  From: java-common/default-jre@2:1.11-72 > java-common/default-jre-headless@2:1.11-72 > openjdk-lts/openjdk-11-jre-headless@11.0.11+9-0ubuntu2~20.04 > cups/libcups2@2.3.1-9ubuntu1.1 > avahi/libavahi-client3@0.7-4ubuntu7
  From: meta-common-packages@meta > avahi/libavahi-common-data@0.7-4ubuntu7
  and 1 more...
  Image layer: '/bin/sh -c DEBIAN_FRONTEND=noninteractive &&     export DEBIAN_FRONTEND &&     apt-get update &&     apt-get install --yes --no-install-recommends     default-jre     ghostscript     graphicsmagick     libreoffice     libreoffice-java-common     pdftk     poppler-utils     python3     python3-magic     python3-pil     sudo     tesseract-ocr     tesseract-ocr-all     &&     apt-get upgrade --yes &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* &&     useradd --no-log-init --create-home --shell /bin/bash user'



Package manager:   deb
Project name:      docker-image|flmcode/dangerzone
Docker image:      flmcode/dangerzone
Platform:          linux/amd64

Tested 521 dependencies for known vulnerabilities, found 60 vulnerabilities.

For more free scans that keep your images secure, sign up to Snyk at https://dockr.ly/3ePqVcp
```